### PR TITLE
Support json1 extension functions

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/psi/FunctionExprMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/psi/FunctionExprMixin.kt
@@ -71,6 +71,19 @@ internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
     "nullif" -> exprList[0].type().asNullable()
     "max" -> encapsulatingType(exprList, SqliteType.INTEGER, SqliteType.REAL, SqliteType.TEXT, SqliteType.BLOB).asNullable()
     "min" -> encapsulatingType(exprList, SqliteType.BLOB, SqliteType.TEXT, SqliteType.INTEGER, SqliteType.REAL).asNullable()
+
+    // json1
+
+    "json", "json_remove", "json_extract", "json_insert", "json_replace", "json_set" -> {
+      IntermediateType(TEXT).nullableIf(exprList[0].type().javaType.isNullable)
+    }
+    "json_array", "json_object", "json_group_array", "json_group_object" -> IntermediateType(TEXT)
+    "json_array_length" -> IntermediateType(INTEGER).nullableIf(exprList[0].type().javaType.isNullable)
+    "json_patch" -> IntermediateType(TEXT).nullableIf(exprList.any { it.type().javaType.isNullable })
+    "json_type" -> IntermediateType(TEXT).asNullable()
+    "json_valid" -> IntermediateType(INTEGER, BOOLEAN)
+    "json_quote" -> exprList[0].type().asNonNullable()
+
     else -> when ((containingFile as SqlDelightFile).dialect) {
       DialectPreset.SQLITE_3_18, DialectPreset.SQLITE_3_24, DialectPreset.SQLITE_3_25 -> sqliteFunctionType()
       DialectPreset.MYSQL -> mySqlFunctionType()


### PR DESCRIPTION
This is merged into daniel/plangrid-publish, but will be left here just for future reference. 
This is the primary reason we are still publishing our own version of this repo because it does not yet support json1 extensions that we need.