### PR TITLE
Setup artifactory publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,5 +80,6 @@ allprojects {
   }
 
   group = GROUP
-  version = VERSION_NAME
+  version = "${VERSION_NAME}.${System.getenv('PG_BUILD_NUMBER')}"
+  setProperty("VERSION_NAME", version)
 }

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -7,6 +7,18 @@ tasks.named("dokkaGfm").configure {
 
 mavenPublish {
   releaseSigningEnabled = !getGpgKey().isEmpty()
+
+  targets {
+    installLocally {
+        releaseRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
+        snapshotRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
+    }
+    uploadArchives {
+      releaseRepositoryUrl = System.getenv("ARTIFACTORY_PUBLISH_URL")
+      repositoryUsername = System.getenv("ARTIFACTORY_USER")
+      repositoryPassword = System.getenv("ARTIFACTORY_PASSWORD")
+    }
+  }
 }
 
 publishing {
@@ -23,6 +35,7 @@ def getGpgKey() {
 }
 
 signing {
+  required { false }
   def signingKey = getGpgKey()
   if (!signingKey.isEmpty()) {
     useInMemoryPgpKeys(signingKey, "")


### PR DESCRIPTION
Along with the work to add json1, we also need to be able to publish to our internal repositories. This is how we are publishing to our internal Artifactory. Also merged into Daniel/plangrid-publish